### PR TITLE
Fix prompt for API key

### DIFF
--- a/content/komodowakatime.js
+++ b/content/komodowakatime.js
@@ -74,8 +74,10 @@ var komodoWakatime = {
         thisObject.keyPressListener = function (event) {
             thisObject.keyPressEvent(thisObject, event);
         };
-        thisObject.view = ko.views.manager.currentView;
-        thisObject.view.addEventListener('keypress', thisObject.keyPressListener, true);
+        if (ko.views.manager.currentView !== null) {
+            thisObject.view = ko.views.manager.currentView;
+            thisObject.view.addEventListener('keypress', thisObject.keyPressListener, true);
+        }
     },
     fileChanged: function (thisObject, event) {
         thisObject.fileName = event.originalTarget.koDoc.file.displayPath;


### PR DESCRIPTION
After installing the WakaTime add-on, on first load, if there are no
documents open, the 'ko.views.manager.currentView' object is null
